### PR TITLE
Show how to import WordNet in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ Detailed Description
 
 ## WordNet
 
-To load the WordNet KeNet,
+To load WordNet KeNet, import and initialize it,
+	
+	from WordNet.WordNet import WordNet
 
 	a = WordNet()
 


### PR DESCRIPTION
Thank you so much for making all your work on Turkish NLP available as open-source, and in so many different languages!

While trying to use WordNet, I imported it as `from WordNet import WordNet`, but it didn't work. So I went looking for packages that use it to see the examples of how it is imported. I believe it would be clearer for the new users to have the import line in the Readme.
